### PR TITLE
 use pkg_resources legacy style to declare 'openquake' namespace

### DIFF
--- a/openquake/__init__.py
+++ b/openquake/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2010-2025 GEM Foundation
+#
+# OpenQuake GEM Building Taxonomy is free software: you can redistribute
+# it and/or modify it under the terms of the GNU Affero General Public
+# License as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+__import__('pkg_resources').declare_namespace(__name__)

--- a/openquake/gem_taxonomy/version.py
+++ b/openquake/gem_taxonomy/version.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = '1.11.0'
+__version__ = '1.11.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "openquake.gem-taxonomy"
 dynamic = ["version"]
 
 dependencies = [
-   "openquake.gem-taxonomy-data @ git+https://github.com/gem/oq-gem-taxonomy-data.git@v1.4.0",
+   "openquake.gem-taxonomy-data @ git+https://github.com/gem/oq-gem-taxonomy-data.git@pkg_resource_ns",
    "parsimonious == 0.10.0"
 ]
 


### PR DESCRIPTION
 (remove in the future openquake/__init__.py file is the plan)