### PR TITLE
add check to avoid multi atoms as arguments (IRP and IRV)

### DIFF
--- a/openquake/gem_taxonomy/classes.py
+++ b/openquake/gem_taxonomy/classes.py
@@ -588,6 +588,10 @@ class GemTaxonomy:
                     [], [], None)
 
                 args_list_canon.append(tree_arg.text)
+                if len(tree_arg.children) > 1 and len(tree_arg.children[1].children) > 0:
+                    raise ValueError(
+                        'Attribute [%s]: composition of atoms not allowed [%s].' % (
+                            attr_base, tree_arg.text))
                 if atom_name not in self.tax['AtomDict']:
                     raise ValueError(
                         'Attribute [%s]: unknown atom [%s].' % (

--- a/openquake/gem_taxonomy/test/validate_test.py
+++ b/openquake/gem_taxonomy/test/validate_test.py
@@ -182,6 +182,8 @@ taxonomy_strings = [
      '        </params>\n    </ATOM>\n</ATTR>\n'),
     ('H:3:5', 'Attribute [H:3:5]: atom [H] requires a maximum of 1 parameter,'
      ' 2 found [H:3:5].'),
+    ('IRI+IRP(TOR+REC)', 'Attribute [IRI+IRP(TOR+REC)]: composition of atoms'
+     ' not allowed [TOR+REC].'),
     ('IRI+IRP(TOR;REC)', None, None, '<ATTR id="0xADDR" name="irregularity">\n'
      '    <ATOM id="0xADDR" name="IRI" title="Irregular structure"/>\n'
      '    <ATOM id="0xADDR" name="IRP" title="Plan irregularities list'

--- a/openquake/gem_taxonomy/version.py
+++ b/openquake/gem_taxonomy/version.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = '1.11.1'
+__version__ = '1.11.2'


### PR DESCRIPTION
IRP and IRV accept arguments that are single atoms, not sequence of atoms joined by '+' character.